### PR TITLE
feat: add statistics section to admin dashboard

### DIFF
--- a/frontend/src/components/Admin/AdminDashboard.jsx
+++ b/frontend/src/components/Admin/AdminDashboard.jsx
@@ -12,7 +12,8 @@ import {
   Plus,
   Edit,
   Trash2,
-  Eye
+  Eye,
+  LayoutDashboard
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import SkillForm from './Forms/SkillForm'
@@ -20,11 +21,12 @@ import ProjectForm from './Forms/ProjectForm'
 import ExperienceForm from './Forms/ExperienceForm'
 import EducationForm from './Forms/EducationForm'
 import ConfirmationModal from './ConfirmationModal'
+import Dashboard from './Dashboard'
 import { API_BASE_URL } from '@/config'
 import { parseTechnologies } from '@/lib/utils'
 
 const AdminDashboard = ({ onLogout }) => {
-  const [activeTab, setActiveTab] = useState('personal')
+  const [activeTab, setActiveTab] = useState('dashboard')
   const [data, setData] = useState({
     personalInfo: null,
     skills: [],
@@ -36,6 +38,7 @@ const AdminDashboard = ({ onLogout }) => {
   const [isSaving, setIsSaving] = useState(false)
 
   const tabs = [
+    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { id: 'personal', label: 'Infos Personnelles', icon: User },
     { id: 'skills', label: 'Compétences', icon: Code },
     { id: 'projects', label: 'Projets', icon: FolderOpen },
@@ -849,6 +852,8 @@ const AdminDashboard = ({ onLogout }) => {
 
   const renderTabContent = () => {
     switch (activeTab) {
+      case 'dashboard':
+        return <Dashboard data={data} />
       case 'personal':
         return <PersonalInfoForm />
       case 'skills':

--- a/frontend/src/components/Admin/Dashboard.jsx
+++ b/frontend/src/components/Admin/Dashboard.jsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { motion } from 'framer-motion'
+import { FolderOpen, Code, Briefcase, GraduationCap } from 'lucide-react'
+
+const StatCard = ({ icon: Icon, title, value, color }) => (
+  <motion.div
+    className="bg-card p-6 rounded-lg neon-border flex items-center space-x-4"
+    whileHover={{ scale: 1.05 }}
+    transition={{ duration: 0.2 }}
+  >
+    <div className={`w-16 h-16 rounded-lg flex items-center justify-center`} style={{ backgroundColor: `${color}20`}}>
+      <Icon size={32} style={{ color }} />
+    </div>
+    <div>
+      <p className="text-muted-foreground">{title}</p>
+      <p className="text-3xl font-bold text-foreground">{value}</p>
+    </div>
+  </motion.div>
+)
+
+const Dashboard = ({ data }) => {
+  const stats = [
+    {
+      title: 'Projets',
+      value: data.projects.length,
+      icon: FolderOpen,
+      color: '#3b82f6'
+    },
+    {
+      title: 'Compétences',
+      value: data.skills.length,
+      icon: Code,
+      color: '#10b981'
+    },
+    {
+      title: 'Expériences',
+      value: data.experiences.length,
+      icon: Briefcase,
+      color: '#f97316'
+    },
+    {
+      title: 'Formations',
+      value: data.education.length,
+      icon: GraduationCap,
+      color: '#8b5cf6'
+    }
+  ]
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {stats.map((stat, index) => (
+          <StatCard key={index} {...stat} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default Dashboard


### PR DESCRIPTION
- Add a new Dashboard tab to the admin panel.
- Create a Dashboard component to display statistics about the portfolio content.
- The dashboard shows the number of projects, skills, experiences, and education entries.