### PR TITLE
feat: implement image upload for projects

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -8,15 +8,22 @@ from flask_cors import CORS
 from src.models.portfolio import db
 from src.routes.user import user_bp
 from src.routes.portfolio import portfolio_bp
+from src.routes.upload import upload_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
+app.config['UPLOAD_FOLDER'] = os.path.join(os.path.dirname(__file__), 'uploads')
 
 # Enable CORS for all routes
 CORS(app, origins=["https://portfolio-admin-1.onrender.com", "https://xlhyimcl6wjk.manus.space", "https://nghki1czxy8g.manus.space"], supports_credentials=True, methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"], allow_headers=["Content-Type", "Authorization"])
 
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(portfolio_bp, url_prefix='/api')
+app.register_blueprint(upload_bp, url_prefix='/api')
+
+@app.route('/uploads/<filename>')
+def uploaded_file(filename):
+    return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
 
 # uncomment if you need to use database
 app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"

--- a/backend/src/routes/upload.py
+++ b/backend/src/routes/upload.py
@@ -1,0 +1,27 @@
+import os
+from flask import Blueprint, request, jsonify
+from werkzeug.utils import secure_filename
+
+upload_bp = Blueprint('upload', __name__)
+
+UPLOAD_FOLDER = 'src/uploads'
+ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
+
+def allowed_file(filename):
+    return '.' in filename and \
+           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@upload_bp.route('/api/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file part'}), 400
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({'error': 'No selected file'}), 400
+    if file and allowed_file(file.filename):
+        filename = secure_filename(file.filename)
+        upload_path = os.path.join(UPLOAD_FOLDER)
+        os.makedirs(upload_path, exist_ok=True)
+        file.save(os.path.join(upload_path, filename))
+        return jsonify({'url': f'/uploads/{filename}'})
+    return jsonify({'error': 'File type not allowed'}), 400


### PR DESCRIPTION
- Add a new backend endpoint `/api/upload` to handle image uploads.
- Modify the project form in the admin panel to allow direct image uploads instead of requiring a URL.