### PR TITLE
fix: add Flask-Mail to backend dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ PyJWT==2.10.1
 SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 Werkzeug==3.1.3
+Flask-Mail==0.10.0


### PR DESCRIPTION
- Add `Flask-Mail==0.10.0` to `requirements.txt` to ensure the application builds correctly.