### PR TITLE
refactor: Simplify Supabase connection using DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,11 @@ Pour que l'application fonctionne pleinement en production, vous devez configure
 
 #### Base de Données (Supabase/PostgreSQL)
 
-Pour connecter l'application à une base de données PostgreSQL distante (comme celle fournie par Supabase), définissez les variables suivantes. **Si ces variables ne sont pas définies, l'application utilisera une base de données SQLite locale (`backend/src/database/app.db`), ce qui est utile pour le développement.**
+Pour connecter l'application à une base de données PostgreSQL distante (comme celle fournie par Supabase), il vous suffit de définir une seule variable d'environnement. Vous pouvez copier/coller l'URL de connexion (la "Connection string") directement depuis votre tableau de bord Supabase.
 
--   `DB_HOST`: L'adresse du serveur de votre base de données (ex: `aws-0-eu-central-1.pooler.supabase.com`).
--   `DB_NAME`: Le nom de la base de données (généralement `postgres` pour Supabase).
--   `DB_USER`: Le nom d'utilisateur de la base de données.
--   `DB_PASSWORD`: Le mot de passe de la base de données.
--   `DB_PORT`: Le port de connexion (ex: `5432` ou `6543` pour le pooling de connexion Supabase).
+-   `DATABASE_URL`: L'URL complète de connexion à votre base de données PostgreSQL.
+
+**Note importante :** Si la variable `DATABASE_URL` n'est pas définie, l'application basculera automatiquement sur une base de données SQLite locale. C'est idéal pour le développement, car vous n'avez pas besoin de configurer une base de données distante pour travailler sur l'application.
 
 #### Configuration E-mail
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -38,22 +38,20 @@ app.register_blueprint(blog_bp, url_prefix='/api')
 def uploaded_file(filename):
     return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
 
-# Database Configuration - Supabase (PostgreSQL) or fallback to SQLite
-DB_USER = os.environ.get('DB_USER')
-DB_PASSWORD = os.environ.get('DB_PASSWORD')
-DB_HOST = os.environ.get('DB_HOST')
-DB_NAME = os.environ.get('DB_NAME')
-DB_PORT = os.environ.get('DB_PORT', '5432')
+# Database Configuration - Supabase/PostgreSQL or fallback to SQLite
+DATABASE_URL = os.environ.get('DATABASE_URL')
 
-if all([DB_USER, DB_PASSWORD, DB_HOST, DB_NAME]):
-    # If all Supabase variables are set, use PostgreSQL
-    DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-    print("Connecting to PostgreSQL database...")
+if DATABASE_URL:
+    # If DATABASE_URL is set, use it for the remote PostgreSQL database.
+    print("INFO: DATABASE_URL detected. Connecting to external PostgreSQL database...")
+    # Ensure the URI scheme is 'postgresql' for SQLAlchemy compatibility.
+    if DATABASE_URL.startswith("postgres://"):
+        DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
     app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
 else:
-    # Otherwise, fall back to SQLite for local development
+    # If DATABASE_URL is not set, fall back to the local SQLite database for development.
     db_path = os.path.join(os.path.dirname(__file__), 'database', 'app.db')
-    print(f"WARNING: Database environment variables not set. Falling back to SQLite at {db_path}")
+    print(f"INFO: DATABASE_URL not set. Falling back to SQLite database at {db_path}")
     app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{db_path}"
 
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False


### PR DESCRIPTION
Based on user feedback and a review of the Supabase documentation, this commit refactors the database connection logic to be simpler and more aligned with platform best practices.

Instead of requiring five separate environment variables (DB_HOST, DB_USER, etc.), the application now uses a single `DATABASE_URL` environment variable. This is easier for the user to configure, as they can copy the full connection string directly from the Supabase dashboard.

The `README.md` has been updated to reflect this simplified configuration.