### PR TITLE
fix: Add python-dotenv for .env file support

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ typing_extensions==4.14.0
 Werkzeug==3.1.3
 Flask-Mail==0.10.0
 psycopg2-binary==2.9.9
+python-dotenv==1.0.1


### PR DESCRIPTION
This commit adds the `python-dotenv` package to the backend dependencies.

The Flask CLI requires this package to automatically load environment variables from a `.env` file during development. Without it, variables like `DATABASE_URL` were not being loaded, causing the application to fall back to SQLite even when a `.env` file was present.

This change ensures a smoother local development experience.