### PR TITLE
fix: Force UTF-8 encoding for .env files

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,6 +3,12 @@ import sys
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+# Explicitly load .env file with UTF-8 encoding to prevent errors on Windows
+from dotenv import load_dotenv
+dotenv_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env')
+if os.path.exists(dotenv_path):
+    load_dotenv(dotenv_path=dotenv_path, encoding='utf-8')
+
 from flask import Flask, send_from_directory
 from flask_cors import CORS
 from flask_mail import Mail, Message

--- a/backend/src/seed_data.py
+++ b/backend/src/seed_data.py
@@ -15,8 +15,8 @@ def create_app():
     # The .env file is expected to be in the 'backend' directory, which is the parent of 'src'
     dotenv_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env')
     if os.path.exists(dotenv_path):
-        load_dotenv(dotenv_path=dotenv_path)
-        print(f"INFO: Loaded environment variables from {dotenv_path}")
+        load_dotenv(dotenv_path=dotenv_path, encoding='utf-8')
+        print(f"INFO: Loaded environment variables from {dotenv_path} with UTF-8 encoding.")
 
     DATABASE_URL = os.environ.get('DATABASE_URL')
 


### PR DESCRIPTION
This commit resolves the `UnicodeDecodeError` that occurred when running the application or the seed script on some Windows environments.

The error was caused by the `.env` file being read with a default system encoding instead of UTF-8, which failed if the database password or other variables contained special characters.

- `main.py` and `seed_data.py` have been updated to explicitly load the `.env` file with `encoding='utf-8'`, ensuring consistent behavior across all platforms.