### PR TITLE
fix: Change database driver to pg8000 to resolve encoding errors

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,5 +12,5 @@ SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 Werkzeug==3.1.3
 Flask-Mail==0.10.0
-psycopg2-binary==2.9.9
+pg8000==1.30.3
 python-dotenv==1.0.1

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -62,9 +62,11 @@ DATABASE_URL = os.environ.get('DATABASE_URL')
 if DATABASE_URL:
     # If DATABASE_URL is set, use it for the remote PostgreSQL database.
     print("INFO: DATABASE_URL detected. Connecting to external PostgreSQL database...")
-    # Ensure the URI scheme is 'postgresql' for SQLAlchemy compatibility.
+    # Ensure the URI scheme is 'postgresql' for SQLAlchemy, then adapt for the pg8000 driver.
     if DATABASE_URL.startswith("postgres://"):
         DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
+    if DATABASE_URL.startswith("postgresql://"):
+        DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+pg8000://", 1)
     app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
 else:
     # If DATABASE_URL is not set, fall back to the local SQLite database for development.

--- a/backend/src/seed_data.py
+++ b/backend/src/seed_data.py
@@ -23,9 +23,11 @@ def create_app():
     if DATABASE_URL:
         # If DATABASE_URL is set, use it for the remote PostgreSQL database.
         print("INFO: DATABASE_URL detected. Connecting seed script to external PostgreSQL database...")
-        # Ensure the URI scheme is 'postgresql' for SQLAlchemy compatibility.
+        # Ensure the URI scheme is 'postgresql' for SQLAlchemy, then adapt for the pg8000 driver.
         if DATABASE_URL.startswith("postgres://"):
             DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
+        if DATABASE_URL.startswith("postgresql://"):
+            DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+pg8000://", 1)
         app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
     else:
         # If DATABASE_URL is not set, fall back to the local SQLite database.


### PR DESCRIPTION
This commit replaces the `psycopg2` database driver with `pg8000`, a pure Python alternative. This change is intended to be the definitive fix for the persistent `UnicodeDecodeError` encountered on the user's Windows environment, which is likely caused by issues with special characters in the database password and C-library-based driver compilation.

- `requirements.txt` has been updated to use `pg8000`.
- `main.py` and `seed_data.py` have been adapted to use the `postgresql+pg8000://` URI scheme required by the new driver.